### PR TITLE
Shield iOS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,9 @@ This script does the following tasks:
 - Compile an iOS universal static library and put it into an XCFramework.
 
 The `update-sources` script is also the place to make edits when upgrading any of the third-party dependencies. The react-native-zano repo doesn't include these third-party C++ sources, since they are enormous.
+
+For this to work, you need:
+
+- A recent Android SDK, installed at `$ANDROID_HOME`
+- Xcode command-line tools
+- `llvm-objcopy`, provided by `brew install llvm`

--- a/react-native-zano.podspec
+++ b/react-native-zano.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package['license']
   s.authors      = package['author']
 
-  s.platform     = :ios, "9.0"
+  s.platform     = :ios, "13.0"
   s.requires_arc = true
   s.source = {
     :git => "https://github.com/EdgeApp/react-native-zano.git",

--- a/scripts/update-sources.ts
+++ b/scripts/update-sources.ts
@@ -25,7 +25,7 @@
 // so it's simpler to pull that in from CocoaPods directly.
 //
 
-import { mkdir, readdir, readFile, rm, writeFile } from 'fs/promises'
+import { mkdir, readFile, rm, writeFile } from 'fs/promises'
 import { cpus } from 'os'
 import { join } from 'path'
 
@@ -37,6 +37,7 @@ import {
   quietExec,
   tmpPath
 } from './utils/common'
+import { getObjcopyPath } from './utils/ios-tools'
 
 export const srcPath = join(__dirname, '../src')
 
@@ -241,6 +242,8 @@ async function buildIosZano(platform: IosPlatform): Promise<void> {
   const ar = await quietExec('xcrun', ['--sdk', sdk, '--find', 'ar'])
   const cc = await quietExec('xcrun', ['--sdk', sdk, '--find', 'clang'])
   const cxx = await quietExec('xcrun', ['--sdk', sdk, '--find', 'clang++'])
+  const ld = await quietExec('xcrun', ['--sdk', sdk, '--find', 'ld'])
+  const objcopy = await getObjcopyPath()
   const sdkFlags = [
     '-arch',
     arch,
@@ -316,37 +319,35 @@ async function buildIosZano(platform: IosPlatform): Promise<void> {
     'install'
   ])
 
-  // Explode Zano archives and gather the objects:
-  async function unpackLib(libPath: string, name: string): Promise<void> {
-    console.log(`Unpacking lib${name}.a`)
-    const outPath = join(working, `unpack/${name}`)
-    await rm(outPath, { recursive: true, force: true })
-    await mkdir(outPath, { recursive: true })
-    await loudExec('ar', ['-x', libPath], { cwd: outPath })
+  // Link everything together into a single giant .o file:
+  console.log(`Linking zano-module.o for ${sdk} ${arch}`)
+  const objectPath = join(working, 'zano-module.o')
+  await loudExec(ld, [
+    '-r',
+    '-o',
+    objectPath,
+    ...objects,
+    ...boostLibs.map(name =>
+      join(boostPath, `stage/${sdk}/${arch}/libboost_${name}.a`)
+    ),
+    ...zanoLibs.map(name => join(working, `lib/lib${name}.a`))
+  ])
 
-    // Add object files to the list:
-    for (const file of await readdir(outPath)) {
-      if (file.endsWith('.o')) objects.push(join(outPath, file))
-    }
-  }
-  for (const lib of zanoLibs) {
-    await unpackLib(join(working, `lib/lib${lib}.a`), lib)
-  }
-  for (const lib of boostLibs) {
-    await unpackLib(
-      join(
-        tmpPath,
-        `zano_native_lib/_libs_ios/boost/stage/${sdk}/${arch}/libboost_${lib}.a`
-      ),
-      `boost_${lib}`
-    )
-  }
+  // Localize all symbols except the ones we really want,
+  // hiding them from future linking steps:
+  await loudExec(objcopy, [
+    objectPath,
+    '-w',
+    '-L*',
+    '-L!_zanoMethods',
+    '-L!_zanoMethodCount'
+  ])
 
   // Generate a static library:
   console.log(`Building static library for ${sdk}-${arch}...`)
   const library = join(working, `libzano-module.a`)
   await rm(library, { force: true })
-  await loudExec(ar, ['rcs', library, ...objects])
+  await loudExec(ar, ['rcs', library, objectPath])
 }
 
 /**

--- a/scripts/update-sources.ts
+++ b/scripts/update-sources.ts
@@ -122,8 +122,8 @@ const iosPlatforms: IosPlatform[] = [
   // { sdk: 'iphoneos', arch: 'armv7s' },
 ]
 const iosSdkTriples: { [sdk: string]: string } = {
-  iphoneos: '%arch%-apple-ios9.0',
-  iphonesimulator: '%arch%-apple-ios9.0-simulator'
+  iphoneos: '%arch%-apple-ios13.0',
+  iphonesimulator: '%arch%-apple-ios13.0-simulator'
 }
 
 /**
@@ -245,7 +245,7 @@ async function buildIosZano(platform: IosPlatform): Promise<void> {
   ]
   const cflags = [
     ...includePaths.map(path => `-I${join(tmpPath, path)}`),
-    '-miphoneos-version-min=9.0',
+    '-miphoneos-version-min=13.0',
     '-O2',
     '-Werror=partial-availability'
   ]

--- a/scripts/update-sources.ts
+++ b/scripts/update-sources.ts
@@ -25,7 +25,7 @@
 // so it's simpler to pull that in from CocoaPods directly.
 //
 
-import { mkdir, readdir, rm } from 'fs/promises'
+import { mkdir, readdir, readFile, rm, writeFile } from 'fs/promises'
 import { cpus } from 'os'
 import { join } from 'path'
 
@@ -68,6 +68,12 @@ async function downloadSources(): Promise<void> {
     'https://github.com/moritz-wundke/Boost-for-Android.git',
     '51924ec5533a4fefb5edf99feaeded794c06a4fb'
   )
+
+  // Rename the compress function in RIPEMD160.c,
+  // since that conflicts with Zlib:
+  const mdPath = join(tmpPath, 'zano_native_lib/Zano/src/crypto/RIPEMD160.h')
+  const mdText = await readFile(mdPath, 'utf8')
+  await writeFile(mdPath, '#define compress md_compress\n' + mdText)
 }
 
 // Compiler options:

--- a/scripts/utils/ios-tools.ts
+++ b/scripts/utils/ios-tools.ts
@@ -1,0 +1,23 @@
+import { fileExists, quietExec } from './common'
+
+/**
+ * Finds llvm-objcopy in Homebrew.
+ *
+ * Homebrew doesn't symlink LLVM into the normal location,
+ * to avoid conflicting with Xcode's built-in tools.
+ * We can get around this by looking in the right places.
+ */
+export async function getObjcopyPath(): Promise<string> {
+  const whichPath = await quietExec('which', ['llvm-objcopy']).catch(() => {})
+  if (whichPath != null) return whichPath
+
+  const paths = [
+    '/opt/homebrew/opt/llvm/bin/llvm-objcopy',
+    '/usr/local/opt/llvm/bin/llvm-objcopy' // for Intel Macs
+  ]
+  for (const path of paths) {
+    if (await fileExists(path)) return path
+  }
+
+  throw new Error('Please install `llvm-objcopy` using `brew install llvm`.')
+}


### PR DESCRIPTION
We want to hide all symbols from the final output except the two we actually use. That way our internal symbols won't conflict with ones used in other copies of Boost.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210093433908742