### PR TITLE
Upgrade zano lib to 239d4a39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.2.6 (2026-01-29)
+
+- changed: Update `zano_native_lib` to `239d4a39`
+
 ## 0.2.5 (2025-11-17)
 
 - fixed: Show proper messages for C++ errors.

--- a/scripts/update-sources.ts
+++ b/scripts/update-sources.ts
@@ -62,7 +62,7 @@ async function downloadSources(): Promise<void> {
   await getRepo(
     'zano_native_lib',
     'https://github.com/hyle-team/zano_native_lib.git',
-    '391a965d1d609f917cc97908b9d354a7f54e0258'
+    '239d4a391a92e6f1816540084b725499d9f4accc'
   )
   await getRepo(
     'Boost-for-Android',
@@ -317,7 +317,9 @@ async function buildIosZano(platform: IosPlatform): Promise<void> {
     '--config',
     'Release',
     '--target',
-    'install'
+    'install',
+    '--',
+    'CODE_SIGNING_ALLOWED=NO'
   ])
 
   // Link everything together into a single giant .o file:


### PR DESCRIPTION
The additional argument CODE_SIGNING_ALLOWED=NO gets around an issue building the zlib library

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the pinned native `zano_native_lib` revision and tweaks the iOS CMake build invocation; changes may affect native binary compatibility and build reproducibility across CI/dev machines.
> 
> **Overview**
> Updates the pinned `zano_native_lib` source revision to `239d4a39` and documents the change as release `0.2.6` in `CHANGELOG.md`.
> 
> Adjusts the iOS CMake build step to pass `CODE_SIGNING_ALLOWED=NO` during `cmake --build`, preventing code-signing from interfering with building bundled dependencies (e.g., zlib) when producing the XCFramework.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8326f06da3ed25b67975d921431859dc25e94335. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213016755104967