### PR TITLE
Fix invalid std::vector<const std::string> types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Remove invalid const qualifier from std::vector element types to fix Xcode 26 builds
+
 ## 0.2.7 (2026-02-15)
 
 - fixed: Add missing `wrap` and `auditable` fields to `AddressInfo` type

--- a/ios/ZanoModule.mm
+++ b/ios/ZanoModule.mm
@@ -18,7 +18,7 @@ RCT_REMAP_METHOD(
 
   // Re-package the arguments:
   NSUInteger length = [arguments count];
-  std::vector<const std::string> strings;
+  std::vector<std::string> strings;
   strings.reserve(length);
   for (NSUInteger i = 0; i < length; ++i) {
     NSString *string = [arguments objectAtIndex:i];

--- a/src/jni/jni.cpp
+++ b/src/jni/jni.cpp
@@ -23,7 +23,7 @@ Java_app_edge_rnzano_RnZanoModule_callZanoJNI(
 
   // Re-package the arguments:
   jsize length = env->GetArrayLength(arguments);
-  std::vector<const std::string> strings;
+  std::vector<std::string> strings;
   strings.reserve(length);
   for (jsize i = 0; i < length; ++i) {
     jstring string = (jstring)env->GetObjectArrayElement(arguments, i);

--- a/src/zano-wrapper/zano-methods.cpp
+++ b/src/zano-wrapper/zano-methods.cpp
@@ -4,12 +4,12 @@
 #include "zano-methods.hpp"
 
 
-std::string hello(const std::vector<const std::string> &args) {
+std::string hello(const std::vector<std::string> &args) {
   printf("Zano says hello\n");
   return "hello";
 }
 
-std::string init(const std::vector<const std::string> &args) {
+std::string init(const std::vector<std::string> &args) {
   return plain_wallet::init(
     args[0], // address
     args[1], // cwd
@@ -17,7 +17,7 @@ std::string init(const std::vector<const std::string> &args) {
   );
 }
 
-std::string initWithIpPort(const std::vector<const std::string> &args) {
+std::string initWithIpPort(const std::vector<std::string> &args) {
   return plain_wallet::init(
     args[0], // ip
     args[1], // port
@@ -26,112 +26,112 @@ std::string initWithIpPort(const std::vector<const std::string> &args) {
   );
 }
 
-std::string reset(const std::vector<const std::string> &args) {
+std::string reset(const std::vector<std::string> &args) {
   return plain_wallet::reset();
 }
 
-std::string setLogLevel(const std::vector<const std::string> &args) {
+std::string setLogLevel(const std::vector<std::string> &args) {
   return plain_wallet::set_log_level(std::stoi(args[0]));
 }
 
-std::string getVersion(const std::vector<const std::string> &args) {
+std::string getVersion(const std::vector<std::string> &args) {
   return plain_wallet::get_version();
 }
 
-std::string getWalletFiles(const std::vector<const std::string> &args) {
+std::string getWalletFiles(const std::vector<std::string> &args) {
   return plain_wallet::get_wallet_files();
 }
 
-std::string getExportPrivateInfo(const std::vector<const std::string> &args) {
+std::string getExportPrivateInfo(const std::vector<std::string> &args) {
   return plain_wallet::get_export_private_info(args[0]);
 }
 
-std::string deleteWallet(const std::vector<const std::string> &args) {
+std::string deleteWallet(const std::vector<std::string> &args) {
   return plain_wallet::delete_wallet(args[0]);
 }
 
-std::string getAddressInfo(const std::vector<const std::string> &args) {
+std::string getAddressInfo(const std::vector<std::string> &args) {
   return plain_wallet::get_address_info(args[0]);
 }
 
-std::string getAppconfig(const std::vector<const std::string> &args) {
+std::string getAppconfig(const std::vector<std::string> &args) {
   return plain_wallet::get_appconfig(args[0]);
 }
 
-std::string setAppconfig(const std::vector<const std::string> &args) {
+std::string setAppconfig(const std::vector<std::string> &args) {
   return plain_wallet::set_appconfig(args[0], args[1]);
 }
 
-std::string generateRandomKey(const std::vector<const std::string> &args) {
+std::string generateRandomKey(const std::vector<std::string> &args) {
   return plain_wallet::generate_random_key(std::stoull(args[0]));
 }
 
-std::string getLogsBuffer(const std::vector<const std::string> &args) {
+std::string getLogsBuffer(const std::vector<std::string> &args) {
   return plain_wallet::get_logs_buffer();
 }
 
-std::string truncateLog(const std::vector<const std::string> &args) {
+std::string truncateLog(const std::vector<std::string> &args) {
   return plain_wallet::truncate_log();
 }
 
-std::string getConnectivityStatus(const std::vector<const std::string> &args) {
+std::string getConnectivityStatus(const std::vector<std::string> &args) {
   return plain_wallet::get_connectivity_status();
 }
 
-std::string open(const std::vector<const std::string> &args) {
+std::string open(const std::vector<std::string> &args) {
   return plain_wallet::open(args[0], args[1]);
 }
 
-std::string restore(const std::vector<const std::string> &args) {
+std::string restore(const std::vector<std::string> &args) {
   return plain_wallet::restore(args[0], args[1], args[2], args[3]);
 }
 
-std::string generate(const std::vector<const std::string> &args) {
+std::string generate(const std::vector<std::string> &args) {
   return plain_wallet::generate(args[0], args[1]);
 }
 
-std::string getOpenedWallets(const std::vector<const std::string> &args) {
+std::string getOpenedWallets(const std::vector<std::string> &args) {
   return plain_wallet::get_opened_wallets();
 }
 
-std::string getWalletStatus(const std::vector<const std::string> &args) {
+std::string getWalletStatus(const std::vector<std::string> &args) {
   return plain_wallet::get_wallet_status(std::stoll(args[0]));
 }
 
-std::string closeWallet(const std::vector<const std::string> &args) {
+std::string closeWallet(const std::vector<std::string> &args) {
   return plain_wallet::close_wallet(std::stoll(args[0]));
 }
 
-std::string invoke(const std::vector<const std::string> &args) {
+std::string invoke(const std::vector<std::string> &args) {
   return plain_wallet::invoke(std::stoll(args[0]), args[1]);
 }
 
-std::string asyncCall(const std::vector<const std::string> &args) {
+std::string asyncCall(const std::vector<std::string> &args) {
   return plain_wallet::async_call(args[0], std::stoull(args[1]), args[2]);
 }
 
-std::string tryPullResult(const std::vector<const std::string> &args) {
+std::string tryPullResult(const std::vector<std::string> &args) {
   return plain_wallet::try_pull_result(std::stoull(args[0]));
 }
 
-std::string syncCall(const std::vector<const std::string> &args) {
+std::string syncCall(const std::vector<std::string> &args) {
   return plain_wallet::sync_call(args[0], std::stoull(args[1]), args[2]);
 }
 
-std::string isWalletExist(const std::vector<const std::string> &args) {
+std::string isWalletExist(const std::vector<std::string> &args) {
   bool exists = plain_wallet::is_wallet_exist(args[0]);
   return std::to_string(exists);
 }
 
-std::string getWalletInfo(const std::vector<const std::string> &args) {
+std::string getWalletInfo(const std::vector<std::string> &args) {
   return plain_wallet::get_wallet_info(std::stoll(args[0]));
 }
 
-std::string resetWalletPassword(const std::vector<const std::string> &args) {
+std::string resetWalletPassword(const std::vector<std::string> &args) {
   return plain_wallet::reset_wallet_password(std::stoll(args[0]), args[1]);
 }
 
-std::string getCurrentTxFee(const std::vector<const std::string> &args) {
+std::string getCurrentTxFee(const std::vector<std::string> &args) {
   uint64_t fee = plain_wallet::get_current_tx_fee(std::stoull(args[0]));
   return std::to_string(fee);
 }

--- a/src/zano-wrapper/zano-methods.hpp
+++ b/src/zano-wrapper/zano-methods.hpp
@@ -7,7 +7,7 @@
 struct ZanoMethod {
   const char *name;
   int argc;
-  std::string (*method)(const std::vector<const std::string> &args);
+  std::string (*method)(const std::vector<std::string> &args);
 };
 extern const ZanoMethod zanoMethods[];
 extern const unsigned zanoMethodCount;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Type/signature-only changes in native bridge code intended to restore compilation; runtime behavior should be unchanged aside from potential ABI mismatches if any external code depended on the old signatures.
> 
> **Overview**
> Fixes native builds on newer toolchains by removing the invalid `const` qualifier from `std::vector<const std::string>` argument containers.
> 
> This updates the iOS bridge (`ZanoModule.mm`), Android JNI (`src/jni/jni.cpp`), and the C++ wrapper method signatures (`zano-methods.hpp/.cpp`) to consistently use `std::vector<std::string>`, and records the fix in the Unreleased changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f9aaefee3eb2d51c3ec4ab3b6fadd94671a5d66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213205218458199