### PR TITLE
Add wrap field to AddressInfo type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Add missing `wrap` and `auditable` fields to `AddressInfo` type
+
 ## 0.2.6 (2026-01-29)
 
 - changed: Update `zano_native_lib` to `239d4a39`

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,9 +25,10 @@ export interface WalletFiles {
 
 export interface AddressInfo {
   valid: boolean
+  auditable: boolean
   is_integrated: boolean
   payment_id?: string
-  address: string
+  wrap: boolean
 }
 
 export interface ConnectivityStatus {


### PR DESCRIPTION
The native Zano library returns a wrap field indicating whether an address is a wrapped ETH address (0x...) used for cross-chain bridge transactions. This field was missing from the TypeScript type definition.

Also removed the address field which is not returned by the native get_address_info function (the C++ code returns valid, auditable, payment_id, and wrap fields only).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only adjustments plus a changelog entry; main risk is minor compile-time breakage for any consumers referencing the removed `address` field.
> 
> **Overview**
> Fixes the `AddressInfo` TypeScript definition to match the native `getAddressInfo` response by **adding `auditable` and `wrap`** and **removing the unused `address` field**.
> 
> Updates the changelog to note the corrected `AddressInfo` type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 072dd1e2a4bea983e7d48b82604eb7b43002577c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->