### PR TITLE
Update zano_native_lib to a523871 for HF6 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- changed: Update `zano_native_lib` to `a523871` for Zano HF6 support.
+- changed: Build the iOS library against the prebuilt `libzano-plain-wallet` xcframework, since `zano_native_lib` no longer ships the raw `_libs_ios` OpenSSL and Boost archives.
+
 ## 0.3.0 (2026-06-13)
 
 - changed: Convert the build tooling from Yarn to npm.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-zano",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-zano",
-      "version": "0.2.8",
+      "version": "0.3.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "cleaners": "^0.3.17"

--- a/scripts/update-sources.ts
+++ b/scripts/update-sources.ts
@@ -62,7 +62,7 @@ async function downloadSources(): Promise<void> {
   await getRepo(
     'zano_native_lib',
     'https://github.com/hyle-team/zano_native_lib.git',
-    '239d4a391a92e6f1816540084b725499d9f4accc'
+    'a523871b74257cdcffa5fa6537cca904def916d6'
   )
   await getRepo(
     'Boost-for-Android',
@@ -231,13 +231,29 @@ async function buildAndroidZano(platform: AndroidPlatform): Promise<void> {
 }
 
 /**
- * Invokes CMake to build Zano,
- * then combines everything into a big .o file.
+ * Compiles our wrapper and links it against the prebuilt
+ * libzano-plain-wallet static library (which already bundles Zano,
+ * Boost, and OpenSSL), then localizes symbols into a static lib.
+ *
+ * As of zano_native_lib HF6, the repo no longer ships the raw
+ * `_libs_ios` OpenSSL/Boost archives we used to build Zano from
+ * source against. Instead it provides prebuilt xcframeworks, so we
+ * link the plain-wallet bundle directly.
  */
 async function buildIosZano(platform: IosPlatform): Promise<void> {
-  const { sdk, arch, cmakePlatform } = platform
+  const { sdk, arch } = platform
   const working = join(tmpPath, `${sdk}-${arch}`)
   await mkdir(working, { recursive: true })
+
+  // The prebuilt plain-wallet xcframework slice for this SDK:
+  const slice = sdk === 'iphoneos' ? 'ios-arm64' : 'ios-arm64_x86_64-simulator'
+  const framework = join(
+    tmpPath,
+    'zano_native_lib/_install_ios/lib/libzano-plain-wallet.xcframework',
+    slice
+  )
+  const zanoLib = join(framework, 'libzano-plain-wallet.a')
+  const headersPath = join(framework, 'Headers')
 
   // Find platform tools:
   const ar = await quietExec('xcrun', ['--sdk', sdk, '--find', 'ar'])
@@ -254,7 +270,7 @@ async function buildIosZano(platform: IosPlatform): Promise<void> {
     await quietExec('xcrun', ['--sdk', sdk, '--show-sdk-path'])
   ]
   const cflags = [
-    ...includePaths.map(path => `-I${join(tmpPath, path)}`),
+    `-I${headersPath}`,
     '-miphoneos-version-min=13.0',
     '-O2',
     '-Werror=partial-availability'
@@ -283,57 +299,19 @@ async function buildIosZano(platform: IosPlatform): Promise<void> {
     ])
   }
 
-  // Build Zano itself:
-  const boostPath = join(tmpPath, `zano_native_lib/_libs_ios/boost`)
-  const sslPath = join(tmpPath, `zano_native_lib/_libs_ios/OpenSSL/${sdk}`)
-  const iosToolchain = join(
-    tmpPath,
-    'zano_native_lib/ios-cmake/ios.toolchain.cmake'
-  )
-  await loudExec('cmake', [
-    // Source directory:
-    `-S${join(tmpPath, 'zano_native_lib/Zano')}`,
-    // Build directory:
-    `-B${join(working, 'cmake')}`,
-    // Build options:
-    `-DBoost_INCLUDE_DIRS=${join(boostPath, 'include')}`,
-    `-DBoost_LIBRARY_DIRS=${join(boostPath, `stage/${sdk}/${arch}`)}`,
-    `-DBoost_VERSION="1.84.0"`,
-    `-DCMAKE_BUILD_TYPE=Release`,
-    `-DCMAKE_INSTALL_PREFIX=${working}`,
-    `-DCMAKE_SYSTEM_NAME=iOS`,
-    `-DCMAKE_TOOLCHAIN_FILE=${iosToolchain}`,
-    `-DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH=NO`,
-    `-DDISABLE_TOR=TRUE`,
-    `-DOPENSSL_CRYPTO_LIBRARY=${join(sslPath, 'lib/libcrypto.a')}`,
-    `-DOPENSSL_INCLUDE_DIR=${join(sslPath, 'include')}`,
-    `-DOPENSSL_SSL_LIBRARY=${join(sslPath, 'lib/libssl.a')}`,
-    `-DPLATFORM=${cmakePlatform}`,
-    `-GXcode`
-  ])
-  await loudExec('cmake', [
-    '--build',
-    join(working, 'cmake'),
-    '--config',
-    'Release',
-    '--target',
-    'install',
-    '--',
-    'CODE_SIGNING_ALLOWED=NO'
-  ])
-
-  // Link everything together into a single giant .o file:
+  // Link our wrapper against the prebuilt plain-wallet library
+  // into a single relocatable object. `ld -r` pulls in only the
+  // archive members our wrapper transitively needs:
   console.log(`Linking zano-module.o for ${sdk} ${arch}`)
   const objectPath = join(working, 'zano-module.o')
   await loudExec(ld, [
     '-r',
+    '-arch',
+    arch,
     '-o',
     objectPath,
     ...objects,
-    ...boostLibs.map(name =>
-      join(boostPath, `stage/${sdk}/${arch}/libboost_${name}.a`)
-    ),
-    ...zanoLibs.map(name => join(working, `lib/lib${name}.a`))
+    zanoLib
   ])
 
   // Localize all symbols except the ones we really want,


### PR DESCRIPTION
### Description

Zano HF6 support: upgrade `zano_native_lib` to `a523871`.

Asana: https://app.asana.com/1/9976422036640/project/1213843652804305/task/1215784489950972

The HF6 release of `zano_native_lib` removed the raw `_libs_ios` OpenSSL and Boost archives the iOS build used to link against, and now ships prebuilt xcframeworks instead. This reworks the iOS path in `update-sources.ts` to compile the wrapper and link it against the prebuilt `libzano-plain-wallet` xcframework (which bundles Zano, Boost, and OpenSSL), while preserving the partial-link plus `objcopy` symbol localization so only `zanoMethods` and `zanoMethodCount` stay exported. Android is unchanged, since `zano_native_lib` still ships the raw `_libs_android` archives that path builds from.

The branch also carries a package-lock.json version sync (0.2.8 to 0.3.0) that the 0.3.0 release left stale.

### Changes

- Update `zano_native_lib` to `a523871` for HF6.
- Rework the iOS build to link against the prebuilt `libzano-plain-wallet.xcframework`.
- Add CHANGELOG entries for both.
- Sync package-lock.json to 0.3.0.

### Testing

- Android: built all four ABIs (`librnzano.so` for arm64-v8a, armeabi-v7a, x86, x86_64) with no errors.
- iOS: built `ZanoModule.xcframework` (device slice plus fat simulator slice). Verified with `nm` that only `_zanoMethods` and `_zanoMethodCount` are exported and every other global symbol is localized.
- Integration: copied both artifacts into a local edge-react-gui `node_modules/react-native-zano` and built the iOS app (Release, simulator). Result was `** BUILD SUCCEEDED **` with the zano symbols present in the app binary and no link errors attributable to this module.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> iOS native linking and dependency packaging changed in a security-sensitive crypto wallet module; Android is untouched but HF6 upgrades affect shipped binaries.
> 
> **Overview**
> **Bumps `zano_native_lib` to `a523871` for Zano HF6** and documents the change in the changelog.
> 
> **Reworks the iOS path in `update-sources.ts`:** instead of CMake-building Zano and linking `_libs_ios` Boost/OpenSSL archives, the script compiles the wrapper with headers from the prebuilt `libzano-plain-wallet.xcframework`, partial-links against `libzano-plain-wallet.a`, and still runs `objcopy` so only `_zanoMethods` and `_zanoMethodCount` stay exported. Android sourcing and build flow are unchanged.
> 
> Also **syncs `package-lock.json` to version `0.3.0`** (was still `0.2.8`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 893c48f7c5ff272716c757d45cef778674489ffa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->